### PR TITLE
Revert "Support passing in sha256 of scala version src jars to `scala_reposit…"

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -17,7 +17,6 @@ load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
     _default_scala_version = "default_scala_version",
     _default_scala_version_jar_shas = "default_scala_version_jar_shas",
-    _default_scala_version_src_jar_shas = "default_scala_version_src_jar_shas",
     _extract_major_version = "extract_major_version",
     _new_scala_default_repository = "new_scala_default_repository",
 )
@@ -329,20 +328,18 @@ def scala_repositories(
         scala_version_shas = (
             _default_scala_version(),
             _default_scala_version_jar_shas(),
-            _default_scala_version_src_jar_shas(),
         ),
         maven_servers = ["http://central.maven.org/maven2"],
         scala_extra_jars = _default_scala_extra_jars(),
-        fetch_scala_version_sources = False):
-    (scala_version, scala_version_jar_shas, scala_version_src_jar_shas) = scala_version_shas
+        fetch_sources = False):
+    (scala_version, scala_version_jar_shas) = scala_version_shas
     major_version = _extract_major_version(scala_version)
 
     _new_scala_default_repository(
         scala_version = scala_version,
         scala_version_jar_shas = scala_version_jar_shas,
-        scala_version_src_jar_shas = scala_version_src_jar_shas,
         maven_servers = maven_servers,
-        fetch_sources = fetch_scala_version_sources,
+        fetch_sources = fetch_sources,
     )
 
     scala_version_extra_jars = scala_extra_jars[major_version]
@@ -356,6 +353,7 @@ def scala_repositories(
         jar_sha256 = scala_version_extra_jars["scalatest"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_scalactic",
@@ -366,6 +364,7 @@ def scala_repositories(
         jar_sha256 = scala_version_extra_jars["scalactic"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     _scala_maven_import_external(
@@ -378,6 +377,7 @@ def scala_repositories(
         jar_sha256 = scala_version_extra_jars["scala_xml"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     _scala_maven_import_external(
@@ -391,6 +391,7 @@ def scala_repositories(
         jar_sha256 = scala_version_extra_jars["scala_parser_combinators"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     _scala_maven_import_external(
@@ -399,6 +400,7 @@ def scala_repositories(
         jar_sha256 = "8d7ec605ca105747653e002bfe67bddba90ab964da697aaa5daa1060923585db",
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     # used by ScalacProcessor
@@ -408,6 +410,7 @@ def scala_repositories(
         jar_sha256 = "f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513",
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     # Template for binary launcher

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -31,13 +31,6 @@ def default_scala_version_jar_shas():
         "scala_reflect": "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
     }
 
-def default_scala_version_src_jar_shas():
-    return {
-        "scala_compiler": "d57797fe3982d69d56d432046459f5b72e87a422170d98cf295c3b1bbe93f456",
-        "scala_library": "a32ccfac851adeb094a31134af1034d0ba026512931433cba86d5dd12d91f1ff",
-        "scala_reflect": "4d4adbc4f5f6be87ec555635dd40926bf71c6d638a06d59d929de04386099063",
-    }
-
 def extract_major_version(scala_version):
     """Return major Scala version given a full version, e.g. "2.11.11" -> "2.11" """
     return scala_version[:scala_version.find(".", 2)]
@@ -63,14 +56,12 @@ def scala_mvn_artifact(
 def new_scala_default_repository(
         scala_version,
         scala_version_jar_shas,
-        scala_version_src_jar_shas,
         maven_servers,
         fetch_sources):
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_scala_library",
         artifact = "org.scala-lang:scala-library:{}".format(scala_version),
         jar_sha256 = scala_version_jar_shas["scala_library"],
-        srcjar_sha256 = scala_version_src_jar_shas["scala_library"],
         licenses = ["notice"],
         server_urls = maven_servers,
         fetch_sources = fetch_sources,
@@ -79,7 +70,6 @@ def new_scala_default_repository(
         name = "io_bazel_rules_scala_scala_compiler",
         artifact = "org.scala-lang:scala-compiler:{}".format(scala_version),
         jar_sha256 = scala_version_jar_shas["scala_compiler"],
-        srcjar_sha256 = scala_version_src_jar_shas["scala_compiler"],
         licenses = ["notice"],
         server_urls = maven_servers,
         fetch_sources = fetch_sources,
@@ -88,7 +78,6 @@ def new_scala_default_repository(
         name = "io_bazel_rules_scala_scala_reflect",
         artifact = "org.scala-lang:scala-reflect:{}".format(scala_version),
         jar_sha256 = scala_version_jar_shas["scala_reflect"],
-        srcjar_sha256 = scala_version_src_jar_shas["scala_reflect"],
         licenses = ["notice"],
         server_urls = maven_servers,
         fetch_sources = fetch_sources,


### PR DESCRIPTION
Reverts ConsultingMD/rules_scala#2

turns out this isn't necessary to get `fetch_sources` working